### PR TITLE
Colour of Nav Pill Variation

### DIFF
--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -584,8 +584,8 @@ $nav-tabs-justified-link-border-color:        #ddd !default;
 $nav-tabs-justified-active-link-border-color: $body-bg !default;
 
 $nav-pills-border-radius:     $border-radius !default;
-$nav-pills-active-link-color: $component-active-color !default;
-$nav-pills-active-link-bg:    $component-active-bg !default;
+$nav-pills-active-link-color: $black;
+$nav-pills-active-link-bg:    $gray-lightest;
 
 // Navbar
 


### PR DESCRIPTION
No reason according to our design to have pills more prominent then
light grey in the navigation.

The extra emphasis is unnecessary here.