### PR TITLE
Designupdates closer to beta updates

### DIFF
--- a/assets/css/docs.min.css
+++ b/assets/css/docs.min.css
@@ -1,4 +1,4 @@
-gitgit /*!
+/*!
  * Bootstrap Docs (https://getbootstrap.com)
  * Copyright 2011-2017 The Bootstrap Authors
  * Copyright 2011-2017 Twitter, Inc.

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -272,9 +272,9 @@ $lead-font-weight: 300 !default;
 
 $small-font-size: 80% !default;
 
-$text-muted: $gray-600 !default;
+$text-muted: $gray-400;
 
-$blockquote-small-color:  $gray-600 !default;
+$blockquote-small-color:  $gray-400;
 $blockquote-font-size:    $font-size-lg;
 
 $hr-border-color: rgba($black,.1) !default;

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -540,7 +540,7 @@ $nav-tabs-link-active-border-color:           #ddd !default;
 
 $nav-pills-border-radius:     $border-radius !default;
 $nav-pills-link-active-color: $black;
-$nav-pills-link-active-bg:    $component-active-bg !default;
+$nav-pills-link-active-bg:    $gray-200;
 
 // Navbar
 

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -94,8 +94,8 @@ $colors: (
   cyan: $cyan,
   white: $white,
   gray: $gray-600,
-  gray-dark: $gray-800
-) !default;
+  gray-dark: $gray-900
+);
 
 $theme-colors: (
   primary: $yellow,
@@ -105,7 +105,7 @@ $theme-colors: (
   warning: $orange,
   danger: $red,
   light: $gray-100,
-  dark: $gray-800
+  dark: $gray-900
 );
 
 // Set a specific jump point for requesting color jumps
@@ -160,7 +160,7 @@ $body-color:    $black;
 //
 // Style anchor elements.
 
-$link-color:            theme-color("info") !default;
+$link-color:            theme-color("info");
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -101,12 +101,12 @@ $theme-colors: (
   primary: $yellow,
   secondary: $gray-600,
   success: $green,
-  info: $cyan,
-  warning: $yellow,
+  info: $blue,
+  warning: $orange,
   danger: $red,
   light: $gray-100,
   dark: $gray-800
-) !default;
+);
 
 // Set a specific jump point for requesting color jumps
 $theme-color-interval: 8% !default;

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -353,10 +353,10 @@ $btn-transition:                 all .2s ease-in-out;
 // Forms
 
 $input-bg:                       $white !default;
-$input-disabled-bg:              $gray-200 !default;
+$input-disabled-bg:              $gray-300;
 
 $input-color:                    $black;
-$input-border-color:             rgba($black,.15) !default;
+$input-border-color:             $gray-300;
 $input-btn-border-width:         $border-width !default; // For form controls and buttons
 $input-box-shadow:               inset 0 1px 1px rgba($black,.075) !default;
 
@@ -369,7 +369,7 @@ $input-focus-border-color:       $black;
 $input-focus-box-shadow:         $input-box-shadow, $btn-focus-box-shadow !default;
 $input-focus-color:              $black;
 
-$input-placeholder-color:        $gray-600 !default;
+$input-placeholder-color:        $gray-400;
 
 $input-height-border:           $input-btn-border-width * 2 !default;
 

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -154,7 +154,7 @@ $sizes: (
 // Settings for the `<body>` element.
 
 $body-bg:       $white !default;
-$body-color:    $gray-900 !default;
+$body-color:    $black;
 
 // Links
 //

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -47,15 +47,15 @@
 //
 
 $white:  #fff !default;
-$gray-100: #f8f9fa !default;
-$gray-200: #e9ecef !default;
-$gray-300: #dee2e6 !default;
-$gray-400: #ced4da !default;
-$gray-500: #adb5bd !default;
-$gray-600: #868e96 !default;
-$gray-700: #495057 !default;
-$gray-800: #343a40 !default;
-$gray-900: #212529 !default;
+$gray-100: #f6f5f1;
+$gray-200: #e4e3e1;
+$gray-300: #d3d1cc;
+$gray-400: #b2b0a9;
+$gray-500: #8c8a84;
+$gray-600: #6e6c67;
+$gray-700: #4e4c48;
+$gray-800: #353430;
+$gray-900: #242321;
 $black:  #231a00 !default;
 
 $grays: (

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -160,7 +160,7 @@ $body-color:    $black;
 //
 // Style anchor elements.
 
-$link-color:            theme-color("primary") !default;
+$link-color:            theme-color("info") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -353,7 +353,7 @@ $btn-transition:                 all .2s ease-in-out;
 // Forms
 
 $input-bg:                       $white !default;
-$input-disabled-bg:              $gray-300;
+$input-disabled-bg:              $gray-200;
 
 $input-color:                    $black;
 $input-border-color:             $gray-300;

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -99,7 +99,7 @@ $colors: (
 
 $theme-colors: (
   primary: $yellow,
-  secondary: $gray-600,
+  secondary: $gray-200,
   success: $green,
   info: $blue,
   warning: $orange,

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -403,7 +403,7 @@ $custom-control-spacer-y: .25rem !default;
 $custom-control-spacer-x: 1rem !default;
 
 $custom-control-indicator-size:       1rem !default;
-$custom-control-indicator-bg:         theme-color("success");
+$custom-control-indicator-bg:         $gray-200;
 $custom-control-indicator-bg-size:    50% 50% !default;
 $custom-control-indicator-box-shadow: inset 0 .25rem .25rem rgba($black,.1) !default;
 
@@ -411,7 +411,7 @@ $custom-control-indicator-disabled-bg:       $gray-200 !default;
 $custom-control-description-disabled-color:  $gray-600 !default;
 
 $custom-control-indicator-checked-color:      $white !default;
-$custom-control-indicator-checked-bg:         theme-color("primary") !default;
+$custom-control-indicator-checked-bg:         theme-color("success") !default;
 $custom-control-indicator-checked-box-shadow: none !default;
 
 $custom-control-indicator-focus-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
@@ -423,7 +423,7 @@ $custom-control-indicator-active-box-shadow: none !default;
 $custom-checkbox-border-radius: $border-radius !default;
 $custom-checkbox-icon-checked: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-indicator-checked-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
+$custom-checkbox-indeterminate-bg: $gray-200;
 $custom-checkbox-indicator-indeterminate-color: $custom-control-indicator-checked-color !default;
 $custom-checkbox-icon-indeterminate: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indicator-indeterminate-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -347,7 +347,7 @@ $btn-border-radius:              $border-radius;
 $btn-border-radius-lg:           $border-radius;
 $btn-border-radius-sm:           $border-radius;
 
-$btn-transition:                 all .15s ease-in-out !default;
+$btn-transition:                 all .2s ease-in-out;
 
 
 // Forms

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -353,7 +353,7 @@ $btn-transition:                 all .2s ease-in-out;
 // Forms
 
 $input-bg:                       $white !default;
-$input-disabled-bg:              $gray-200;
+$input-disabled-bg:              $gray-100;
 
 $input-color:                    $black;
 $input-border-color:             $gray-300;

--- a/scss/_rc-custom-adjustments.scss
+++ b/scss/_rc-custom-adjustments.scss
@@ -154,18 +154,17 @@ body {
   font-weight: $font-weight-bold;
 }
 
-.form-group {
-  label, .col-form-label {
-    padding-bottom: 0;
-    margin-bottom: .35rem;
-    font-size: $font-size-sm;
-    font-weight: $font-weight-bold;
-  }
+label, .col-form-label, legend {
+  padding-bottom: 0;
+  margin-bottom: .35rem;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-bold;
+}
 
-  .form-control-feedback {
-    font-size: $font-size-sm;
-    font-weight: $font-weight-bold;
-  }
+
+.form-control-feedback, .invalid-feedback {
+  font-size: $font-size-sm;
+  font-weight: $font-weight-bold;
 }
 
 

--- a/scss/_rc-custom-adjustments.scss
+++ b/scss/_rc-custom-adjustments.scss
@@ -153,7 +153,7 @@ body {
 // Forms
 
 .form-control {
-  padding-left: .8rem;
+  padding: $input-btn-padding-y .8rem;
   font-weight: $font-weight-bold;
 }
 

--- a/scss/_rc-custom-adjustments.scss
+++ b/scss/_rc-custom-adjustments.scss
@@ -76,7 +76,31 @@ body {
 }
 
 .btn-secondary {
+  color: $black;
+}
+
+.btn-secondary, .btn-light {
   border-color: $gray-300;
+}
+
+.btn-light {
+  color: $gray-500;
+}
+
+.btn-outline-secondary {
+  color: $gray-600;
+  border-color: $gray-400;
+  &:hover {
+    color: $black;
+  }
+}
+
+.btn-outline-light {
+  color: $gray-300;
+  border-color: $gray-300;
+  &:hover {
+    color: $black;
+  }
 }
 // Ensures button-groups and dropdowns do not get this emphasis shadow.
 .btn-group {

--- a/scss/_rc-custom-adjustments.scss
+++ b/scss/_rc-custom-adjustments.scss
@@ -208,6 +208,15 @@ label, .col-form-label, legend {
   margin-left: 1.25rem;
 }
 
+.nav-tabs {
+  .nav-item + .nav-item {
+    margin-left: -.05rem;
+  }
+
+  .nav-link {
+    padding: .9rem 2.5rem;
+  }
+}
 
 
 // Pagination

--- a/scss/_rc-custom-adjustments.scss
+++ b/scss/_rc-custom-adjustments.scss
@@ -45,6 +45,7 @@ body {
 .breadcrumb-item {
   font-size: $font-size-sm;
   font-weight: $font-weight-bold;
+  color: theme-color("primary");
   text-transform: uppercase;
 
   a {

--- a/scss/_rc-custom-adjustments.scss
+++ b/scss/_rc-custom-adjustments.scss
@@ -15,6 +15,8 @@
 // Forms
 // Navigation
 // Pagination
+// Badges
+
 
 
 //Variables
@@ -227,4 +229,11 @@ label, .col-form-label, legend {
 
 .page-link {
   color: $black;
+}
+
+// Badges
+
+//fixes odd line height making badges look weird with the new bootstrap update — if thy fix it we can remove it in future
+.badge {
+  line-height: 1.3;
 }

--- a/scss/_rc-custom-adjustments.scss
+++ b/scss/_rc-custom-adjustments.scss
@@ -170,6 +170,9 @@ label, .col-form-label, legend {
   font-weight: $font-weight-bold;
 }
 
+.custom-control-indicator {
+  top: .25rem;
+}
 
 
 // Navigation

--- a/scss/_rc-custom-adjustments.scss
+++ b/scss/_rc-custom-adjustments.scss
@@ -75,6 +75,9 @@ body {
   box-shadow:  $rc-box-shadow;
 }
 
+.btn-secondary {
+  border-color: $gray-300;
+}
 // Ensures button-groups and dropdowns do not get this emphasis shadow.
 .btn-group {
   > .btn {

--- a/scss/_rc-custom-adjustments.scss
+++ b/scss/_rc-custom-adjustments.scss
@@ -191,6 +191,9 @@ label, .col-form-label, legend {
 .nav-link {
   padding: .9rem $nav-link-padding-x;
   color: $black;
+  &:hover {
+    color: $gray-700;
+  }
 }
 
 // The following two classes create the underline on the active link that sits flush to the bottom of the navbar. Together with the breadcrumb design we effectively have the main + secondary menus ready.


### PR DESCRIPTION
Ok, that takes care of most things. Fixed up colors and greys + a bunch of other small thing.

The only thing missing is with this new update the “custom select” element is a little broken. It functions but does not absorb the design adjustments + shows the double arrows twice (see below). It is a bug that I am sure they will catch before release – so we should be good.



<img width="232" alt="custom-select-notabsorbing design" src="https://user-images.githubusercontent.com/2456982/28231676-99d51ff6-68a1-11e7-9683-250af94d2a53.png">
